### PR TITLE
DO NOT optimize solr!

### DIFF
--- a/core/management/commands/purge_batch.py
+++ b/core/management/commands/purge_batch.py
@@ -19,12 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--no-optimize', 
-                    action='store_false', 
-                    dest='optimize', default=True,
-                    help='Do not optimize Solr and MySQL after purge'),
-    )
+    option_list = BaseCommand.option_list
     help = "Purge a batch"
     args = '<batch_location>'
 
@@ -36,14 +31,6 @@ class Command(BaseCommand):
         try:
             log.info("purging batch %s", batch_location)
             loader.purge_batch(batch_location)
-            if options['optimize']:
-                log.info("optimizing solr")
-                solr = SolrConnection(settings.SOLR)
-                solr.optimize()
-                log.info("optimizing MySQL OCR table")
-                cursor = connection.cursor()
-                cursor.execute("OPTIMIZE TABLE core_ocr")
-                log.info("finished optimizing")
         except BatchLoaderException, e:
             log.exception(e)
             raise CommandError("unable to purge batch. check the purge_batch log for clues")


### PR DESCRIPTION
From the docs:

> You may want to optimize an index in certain situations -- ie: if you
> build your index once, and then never modify it.
>
> If you have a rapidly changing index, rather than optimizing, you likely
> simply want to use a lower merge factor. Optimizing is very expensive,
> and if the index is constantly changing, the slight performance boost
> will not last long. The tradeoff is not often worth it for a non static
> index.

Given this, it makes a lot more sense to optimize on demand rather than
implicitly when *purging* a batch, of all things.